### PR TITLE
Added script automation actions for ollama container

### DIFF
--- a/Dockerfile.ollama
+++ b/Dockerfile.ollama
@@ -1,4 +1,8 @@
 FROM ollama/ollama
 
-# Pull model before starting the server
-CMD ollama pull nomic-embed-text && ollama serve
+COPY ./run-ollama.sh /usr/local/bin/run-ollama.sh
+RUN chmod +x /usr/local/bin/run-ollama.sh
+
+EXPOSE 11434
+
+ENTRYPOINT ["/usr/local/bin/run-ollama.sh"]

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -35,7 +35,11 @@ services:
       - .:/app
 
   ollama:
-    image: ollama/ollama
+    build:
+      context: .
+      dockerfile: Dockerfile.ollama
+    environment:
+      - OLLAMA_MODEL=bge-large
     ports:
       - "11434:11434"
     volumes:

--- a/run-ollama.sh
+++ b/run-ollama.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+set -e
+
+MODEL="${OLLAMA_MODEL:-bge-large}"
+
+echo "Starting Ollama server..."
+ollama serve &
+
+# Wait for Ollama server to be ready by checking if `ollama list` works
+echo "Waiting for Ollama server to become available..."
+until ollama list > /dev/null 2>&1; do
+    sleep 1
+done
+
+echo "Ollama server is up."
+echo "Pulling model: $MODEL"
+ollama pull "$MODEL"
+
+# Keep container running
+wait


### PR DESCRIPTION
Added automation for ollama server and model pulling on ollama container using a Shell script to be run on entrypoint when the container starts.
Script: run-ollama.sh
There is a check for ollama server running
Model is now being pulled once on container startup and being persisted in the volume afterwards.
Subsequent start and stop of containers does not pull the model again (it only happens the first time).